### PR TITLE
Change stolon submodule repo url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "images/stolon/stolon"]
 	path = images/stolon/stolon
-	url = git@github.com:sorintlab/stolon.git
+	url = git@github.com:gravitational/stolon.git
+	branch = master

--- a/images/Makefile
+++ b/images/Makefile
@@ -38,8 +38,8 @@ stolon: stolon/bin
 	cd stolon && docker build -t stolon:0.2.0 .
 
 stolon/bin:
-	-git submodule init
-	-git submodule update
+	-git submodule update --init
+	-git submodule update --remote
 	docker run $(DOCKERFLAGS) $(BUILDIMAGE) ./build
 	mkdir -p stolon/bin
 	cp stolon/stolon/bin/* stolon/bin/


### PR DESCRIPTION
Track github.com/gravitational/stolon `master` branch for submodule.
This branch always should be stable and have capability to build with stolon-app