### PR TITLE
Fix "permission denied" on kubectl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ dev-redeploy: dev-clean dev-deploy
 
 .PHONY: dev-deploy
 dev-deploy: dev-push
-	-kubectl label nodes -l role=test stolon-keeper=stolon-keeper
+	-kubectl label nodes -l role=node stolon-keeper=stolon-keeper
 	kubectl create -f dev/bootstrap.yaml
 
 .PHONY: dev-clean

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ dev-redeploy: dev-clean dev-deploy
 
 .PHONY: dev-deploy
 dev-deploy: dev-push
-	-kubectl label nodes -l role=node stolon-keeper=stolon-keeper
+	-kubectl label nodes -l role=test stolon-keeper=stolon-keeper
 	kubectl create -f dev/bootstrap.yaml
 
 .PHONY: dev-clean

--- a/dev/bootstrap.yaml
+++ b/dev/bootstrap.yaml
@@ -25,3 +25,5 @@ spec:
       path: /usr/bin/kubectl
     name: kubectl
   restartPolicy: Never
+  nodeSelector:
+    role: master


### PR DESCRIPTION
Deployment fails with error

```
[22:59:12 agalitsyn@thinkpad gravity master 3f37fda]$ kubectl logs stolon-init
time="2016-07-06T12:30:01Z" level=info msg="starting stolonboot" 
time="2016-07-06T12:30:01Z" level=info msg="creating sentinels" 
time="2016-07-06T12:30:01Z" level=info msg="cmd output: " 
time="2016-07-06T12:30:01Z" level=error msg="[stolon-app/boot.go:29]  [stolon-app/boot.go:56]  fork/exec /usr/local/bin/kubectl: permission denied"
```