### PR TITLE
Put ports back

### DIFF
--- a/resources/keeper.yaml
+++ b/resources/keeper.yaml
@@ -48,8 +48,6 @@ spec:
             value: "false"
           - name: STKEEPER_PG_BIN_PATH
             value: /usr/lib/postgresql/9.4/bin
-          - name: STKEEPER_PORT
-            value: "5433"
         ports:
           - containerPort: 5431
           - containerPort: 5432

--- a/resources/proxy.yaml
+++ b/resources/proxy.yaml
@@ -8,7 +8,7 @@ spec:
   type: NodePort
   ports:
     - port: 5432
-      targetPort: 5434
+      targetPort: 5432
   selector:
     stolon-proxy: "yes"
     stolon-cluster: "kube-stolon"
@@ -49,13 +49,11 @@ spec:
             value: "/etc/etcd/secrets/etcd.key"
           - name: STPROXY_DEBUG
             value: "false"
-          - name: STPROXY_PORT
-            value: "5434"
         ports:
-          - containerPort: 5434
+          - containerPort: 5432
         readinessProbe:
           tcpSocket:
-            port: 5434
+            port: 5432
           initialDelaySeconds: 10
           timeoutSeconds: 5
         volumeMounts:


### PR DESCRIPTION
WIth these settings proxy fails and log message like
```
2016-08-17 08:35:41.617962 [proxy.go:200] I | proxy: no proxyconf available, closing connections to previous master
```

Also straight connecting using service discovery fails
```
psql --host=$STOLON_POSTGRES_SERVICE_HOST --port=$STOLON_POSTGRES_SERVICE_PORT --username=stolon postgres

psql: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

srtace:
accept4(7, {sa_family=AF_INET, sin_port=htons(46244), sin_addr=inet_addr("192.168.122.176")}, [16], SOCK_CLOEXEC|SOCK_NONBLOCK) = 9
read(8, 0xc820298c00, 1024)             = -1 EAGAIN (Resource temporarily unavailable)
futex(0xf3bad8, FUTEX_WAIT, 0, {4, 998660022}) = -1 ETIMEDOUT (Connection timed out)
```

