### PR TITLE
specify node port, bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VER ?= 0.1.1
+VER ?= 0.1.2
 REPOSITORY := gravitational.io
 NAME := stolon-app
 

--- a/resources/proxy.yaml
+++ b/resources/proxy.yaml
@@ -9,6 +9,7 @@ spec:
   ports:
     - port: 5432
       targetPort: 5434
+      nodePort: 31901
   selector:
     stolon-proxy: "yes"
     stolon-cluster: "kube-stolon"


### PR DESCRIPTION
Explicitly specifying a nodePort so we can be sure to steer clear of conflicts.