### PR TITLE
Fix passing postgres password to RPC

### DIFF
--- a/dev/bootstrap.yaml
+++ b/dev/bootstrap.yaml
@@ -25,5 +25,3 @@ spec:
       path: /usr/bin/kubectl
     name: kubectl
   restartPolicy: Never
-  nodeSelector:
-    role: master

--- a/images/Makefile
+++ b/images/Makefile
@@ -41,7 +41,7 @@ $(STOLON_BINS):
 .PHONY: stolon
 stolon: $(STOLON_BINS)
 	docker build -t $(STOLON_TAG) $(PWD)/stolon
-	docker tag $(STOLON_TAG) stolon:latests
+	docker tag $(STOLON_TAG) stolon:latest
 
 STOLONHATEST_BINS := hatest/bin
 $(STOLONHATEST_BINS):

--- a/resources/backup.yaml
+++ b/resources/backup.yaml
@@ -17,7 +17,7 @@ spec:
             value: "true"
           - name: STOLONCTL_DB_USERNAME
             value: "stolon"
-          - name: STOLONCTL_DB_PASSWORD
+          - name: STOLON_DB_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: stolon

--- a/resources/createdb.yaml
+++ b/resources/createdb.yaml
@@ -17,7 +17,7 @@ spec:
             value: "true"
           - name: STOLONCTL_DB_USERNAME
             value: "stolon"
-          - name: STOLONCTL_DB_PASSWORD
+          - name: STOLON_DB_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: stolon

--- a/resources/deletedb.yaml
+++ b/resources/deletedb.yaml
@@ -17,7 +17,7 @@ spec:
             value: "true"
           - name: STOLONCTL_DB_USERNAME
             value: "stolon"
-          - name: STOLONCTL_DB_PASSWORD
+          - name: STOLON_DB_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: stolon

--- a/resources/restore.yaml
+++ b/resources/restore.yaml
@@ -17,7 +17,7 @@ spec:
             value: "true"
           - name: STOLONCTL_DB_USERNAME
             value: "stolon"
-          - name: STOLONCTL_DB_PASSWORD
+          - name: STOLON_DB_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: stolon

--- a/resources/rpc.yaml
+++ b/resources/rpc.yaml
@@ -42,6 +42,11 @@ spec:
             value: "5973"
           - name: STOLONRPC_DB_USERNAME
             value: "stolon"
+          - name: STOLON_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: stolon
+                key: password
         ports:
           - containerPort: 5973
         readinessProbe:


### PR DESCRIPTION
RPC client fails with error:
```
User Message: cmd output: psql: fe_sendauth: no password supplied
```