### PR TITLE
Added per-pod read-only serviceAccounts for the "ns/default"

### DIFF
--- a/resources/backup.yaml
+++ b/resources/backup.yaml
@@ -1,3 +1,45 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-backup
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-backup
+  namespace: default
+rules:
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - secrets
+    resourceNames:
+      - "stolon"
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-backup
+subjects:
+  - kind: ServiceAccount
+    name: stolon-backup
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-backup
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -7,6 +49,7 @@ spec:
     metadata:
       name: stolon-backup
     spec:
+      serviceAccountName: stolon-backup
       containers:
       - name: backup
         image: apiserver:5000/stolon:latest

--- a/resources/backup.yaml
+++ b/resources/backup.yaml
@@ -10,14 +10,22 @@ metadata:
   name: stolon-backup
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - secrets
     resourceNames:
-      - "stolon"
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - configmaps
       - endpoints

--- a/resources/createdb.yaml
+++ b/resources/createdb.yaml
@@ -10,14 +10,22 @@ metadata:
   name: stolon-createdb
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - secrets
     resourceNames:
-      - "stolon"
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - configmaps
       - endpoints
@@ -30,15 +38,16 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
-  name: stolon-backup
+  name: stolon-createdb
 subjects:
   - kind: ServiceAccount
-    name: stolon-backup
+    name: stolon-createdb
     namespace: default
 roleRef:
   kind: Role
-  name: stolon-backup
+  name: stolon-createdb
   apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/resources/createdb.yaml
+++ b/resources/createdb.yaml
@@ -1,3 +1,44 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-createdb
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-createdb
+  namespace: default
+rules:
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - secrets
+    resourceNames:
+      - "stolon"
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-backup
+subjects:
+  - kind: ServiceAccount
+    name: stolon-backup
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-backup
+  apiGroup: rbac.authorization.k8s.io
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -7,6 +48,7 @@ spec:
     metadata:
       name: stolon-createdb
     spec:
+      serviceAccountName: stolon-createdb
       containers:
       - name: createdb
         image: apiserver:5000/stolon:latest

--- a/resources/deletedb.yaml
+++ b/resources/deletedb.yaml
@@ -1,3 +1,45 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-deletedb
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-deletedb
+  namespace: default
+rules:
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - secrets
+    resourceNames:
+      - "stolon"
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-deletedb
+subjects:
+  - kind: ServiceAccount
+    name: stolon-deletedb
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-deletedb
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/resources/deletedb.yaml
+++ b/resources/deletedb.yaml
@@ -10,14 +10,22 @@ metadata:
   name: stolon-deletedb
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - secrets
     resourceNames:
-      - "stolon"
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - configmaps
       - endpoints

--- a/resources/hatest.yaml
+++ b/resources/hatest.yaml
@@ -1,3 +1,45 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-hatest
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-hatest
+  namespace: default
+rules:
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - secrets
+    resourceNames:
+      - "stolon"
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-hatest
+subjects:
+  - kind: ServiceAccount
+    name: stolon-hatest
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-hatest
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -7,6 +49,7 @@ spec:
     metadata:
       name: stolon-hatest
     spec:
+      serviceAccountName: stolon-hatest
       containers:
       - name: hatest
         image: apiserver:5000/stolon-hatest:latest

--- a/resources/hatest.yaml
+++ b/resources/hatest.yaml
@@ -10,14 +10,22 @@ metadata:
   name: stolon-hatest
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - secrets
     resourceNames:
-      - "stolon"
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - configmaps
       - endpoints

--- a/resources/keeper.yaml
+++ b/resources/keeper.yaml
@@ -1,3 +1,47 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-keeper
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-keeper
+  namespace: default
+rules:
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - secrets
+    resourceNames:
+      - "stolon"
+      - "cluster-ca"
+      - "cluster-default-ssl"
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-keeper
+subjects:
+  - kind: ServiceAccount
+    name: stolon-keeper
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-keeper
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -38,6 +82,7 @@ spec:
         app: stolon
         component: keeper
     spec:
+      serviceAccountName: stolon-keeper
       nodeSelector:
         stolon-keeper: "yes"
       containers:
@@ -158,7 +203,12 @@ spec:
             - name: STKEEPER_PG_SSL_CA_FILE
               value: /etc/ssl/cluster-ca/ca.pem
             - name: STKEEPER_PG_SSL_CIPHERS
-              value: "ECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED"
+              value: >-
+                ECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:
+                EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:
+                EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:
+                EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:
+                !DSS:!RC4:!SEED
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/resources/keeper.yaml
+++ b/resources/keeper.yaml
@@ -10,16 +10,24 @@ metadata:
   name: stolon-keeper
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - secrets
     resourceNames:
-      - "stolon"
-      - "cluster-ca"
-      - "cluster-default-ssl"
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+      - stolon
+      - cluster-ca
+      - cluster-default-ssl
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - configmaps
       - endpoints

--- a/resources/restore.yaml
+++ b/resources/restore.yaml
@@ -1,3 +1,45 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-stolon-restore
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-stolon-restore
+  namespace: default
+rules:
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - secrets
+    resourceNames:
+      - "stolon"
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-stolon-restore
+subjects:
+  - kind: ServiceAccount
+    name: stolon-stolon-restore
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-stolon-restore
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/resources/restore.yaml
+++ b/resources/restore.yaml
@@ -2,22 +2,30 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: stolon-stolon-restore
+  name: stolon-restore
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
 metadata:
-  name: stolon-stolon-restore
+  name: stolon-restore
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - secrets
     resourceNames:
-      - "stolon"
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - configmaps
       - endpoints
@@ -30,14 +38,14 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
-  name: stolon-stolon-restore
+  name: stolon-restore
 subjects:
   - kind: ServiceAccount
-    name: stolon-stolon-restore
+    name: stolon-restore
     namespace: default
 roleRef:
   kind: Role
-  name: stolon-stolon-restore
+  name: stolon-restore
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: batch/v1

--- a/resources/rpc.yaml
+++ b/resources/rpc.yaml
@@ -10,16 +10,24 @@ metadata:
   name: stolon-rpc
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - secrets
     resourceNames:
-      - "stolon"
-      - "cluster-ca"
-      - "cluster-default-ssl"
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+      - stolon
+      - cluster-ca
+      - cluster-default-ssl
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - configmaps
       - endpoints

--- a/resources/rpc.yaml
+++ b/resources/rpc.yaml
@@ -1,3 +1,47 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-rpc
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-rpc
+  namespace: default
+rules:
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - secrets
+    resourceNames:
+      - "stolon"
+      - "cluster-ca"
+      - "cluster-default-ssl"
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-rpc
+subjects:
+  - kind: ServiceAccount
+    name: stolon-rpc
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-rpc
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -31,6 +75,7 @@ spec:
         app: stolon
         component: rpc
     spec:
+      serviceAccountName: stolon-rpc
       nodeSelector:
         stolon-keeper: "yes"
       containers:

--- a/resources/sentinel.yaml
+++ b/resources/sentinel.yaml
@@ -10,14 +10,22 @@ metadata:
   name: stolon-sentinel
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - secrets
     resourceNames:
-      - "stolon"
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - configmaps
       - endpoints

--- a/resources/sentinel.yaml
+++ b/resources/sentinel.yaml
@@ -1,3 +1,45 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-sentinel
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-sentinel
+  namespace: default
+rules:
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - secrets
+    resourceNames:
+      - "stolon"
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-sentinel
+subjects:
+  - kind: ServiceAccount
+    name: stolon-sentinel
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-sentinel
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -14,6 +56,7 @@ spec:
         app: stolon
         component: sentinel
     spec:
+      serviceAccountName: stolon-sentinel
       nodeSelector:
         stolon-keeper: "yes"
       containers:

--- a/resources/utils.yaml
+++ b/resources/utils.yaml
@@ -1,3 +1,45 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-utils
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-utils
+  namespace: default
+rules:
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - secrets
+    resourceNames:
+      - "stolon"
+  - apiGroups: [ "" ]
+    verbs:     [ "get" , "list" , "watch" ]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-utils
+subjects:
+  - kind: ServiceAccount
+    name: stolon-utils
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-utils
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -14,6 +56,7 @@ spec:
         app: stolon
         component: utils
     spec:
+      serviceAccountName: stolon-utils
       nodeSelector:
         stolon-keeper: "yes"
       containers:

--- a/resources/utils.yaml
+++ b/resources/utils.yaml
@@ -10,14 +10,22 @@ metadata:
   name: stolon-utils
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - secrets
     resourceNames:
-      - "stolon"
-  - apiGroups: [ "" ]
-    verbs:     [ "get" , "list" , "watch" ]
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
     resources:
       - configmaps
       - endpoints


### PR DESCRIPTION
Added specific per-pod serviceAccounts which has read-only access
specific to the "default" namespace only.

I think this needs to be tagged as 1.7.1, probably.

If this passes, I'll work on back-porting this to 1.6.x as 1.6.1