### PR TITLE
Lele/serviceaccounts per pod hardening backport 160

### DIFF
--- a/images/hook/Dockerfile
+++ b/images/hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/rig:0.0.1
+FROM quay.io/gravitational/rig:0.0.5
 
 ARG CHANGESET
 ENV RIG_CHANGESET $CHANGESET

--- a/resources/backup.yaml
+++ b/resources/backup.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: stolon-backup
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
@@ -39,6 +40,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: stolon-backup
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: stolon-backup
@@ -52,10 +54,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: stolon-backup
+  namespace: default
 spec:
   template:
     metadata:
       name: stolon-backup
+      namespace: default
     spec:
       serviceAccountName: stolon-backup
       containers:

--- a/resources/backup.yaml
+++ b/resources/backup.yaml
@@ -57,6 +57,7 @@ spec:
     metadata:
       name: stolon-backup
     spec:
+      serviceAccountName: stolon-backup
       containers:
       - name: backup
         image: apiserver:5000/stolon:latest

--- a/resources/backup.yaml
+++ b/resources/backup.yaml
@@ -1,3 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-backup
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-backup
+  namespace: default
+rules:
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
+    resourceNames:
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-backup
+subjects:
+  - kind: ServiceAccount
+    name: stolon-backup
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-backup
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/resources/createdb.yaml
+++ b/resources/createdb.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: stolon-createdb
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
@@ -39,6 +40,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: stolon-createdb
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: stolon-createdb
@@ -52,10 +54,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: stolon-createdb
+  namespace: default
 spec:
   template:
     metadata:
       name: stolon-createdb
+      namespace: default
     spec:
       serviceAccountName: stolon-createdb
       containers:

--- a/resources/createdb.yaml
+++ b/resources/createdb.yaml
@@ -57,6 +57,7 @@ spec:
     metadata:
       name: stolon-createdb
     spec:
+      serviceAccountName: stolon-createdb
       containers:
       - name: createdb
         image: apiserver:5000/stolon:latest

--- a/resources/createdb.yaml
+++ b/resources/createdb.yaml
@@ -1,3 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-createdb
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-createdb
+  namespace: default
+rules:
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
+    resourceNames:
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-createdb
+subjects:
+  - kind: ServiceAccount
+    name: stolon-createdb
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-createdb
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/resources/deletedb.yaml
+++ b/resources/deletedb.yaml
@@ -1,3 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-deletedb
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-deletedb
+  namespace: default
+rules:
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
+    resourceNames:
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-deletedb
+subjects:
+  - kind: ServiceAccount
+    name: stolon-deletedb
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-deletedb
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/resources/deletedb.yaml
+++ b/resources/deletedb.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: stolon-deletedb
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
@@ -39,6 +40,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: stolon-deletedb
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: stolon-deletedb
@@ -52,10 +54,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: stolon-deletedb
+  namespace: default
 spec:
   template:
     metadata:
       name: stolon-deletedb
+      namespace: default
     spec:
       containers:
       - name: deletedb

--- a/resources/hatest.yaml
+++ b/resources/hatest.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: stolon-hatest
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
@@ -39,6 +40,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: stolon-hatest
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: stolon-hatest
@@ -52,10 +54,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: stolon-hatest
+  namespace: default
 spec:
   template:
     metadata:
       name: stolon-hatest
+      namespace: default
     spec:
       serviceAccountName: stolon-hatest
       containers:

--- a/resources/hatest.yaml
+++ b/resources/hatest.yaml
@@ -57,6 +57,7 @@ spec:
     metadata:
       name: stolon-hatest
     spec:
+      serviceAccountName: stolon-hatest
       containers:
       - name: hatest
         image: apiserver:5000/stolon-hatest:latest

--- a/resources/hatest.yaml
+++ b/resources/hatest.yaml
@@ -1,3 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-hatest
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-hatest
+  namespace: default
+rules:
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
+    resourceNames:
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-hatest
+subjects:
+  - kind: ServiceAccount
+    name: stolon-hatest
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-hatest
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/resources/keeper.yaml
+++ b/resources/keeper.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: stolon-keeper
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
@@ -41,6 +42,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: stolon-keeper
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: stolon-keeper
@@ -84,6 +86,7 @@ spec:
     metadata:
       labels:
         name: stolon-keeper
+        namespace: default
         stolon-cluster: "kube-stolon"
         stolon-keeper: "yes"
         stolon-proxy: "yes"

--- a/resources/keeper.yaml
+++ b/resources/keeper.yaml
@@ -1,3 +1,55 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-keeper
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-keeper
+  namespace: default
+rules:
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
+    resourceNames:
+      - stolon
+      - cluster-ca
+      - cluster-default-ssl
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-keeper
+subjects:
+  - kind: ServiceAccount
+    name: stolon-keeper
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-keeper
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/resources/keeper.yaml
+++ b/resources/keeper.yaml
@@ -253,7 +253,12 @@ spec:
             - name: STKEEPER_PG_SSL_CA_FILE
               value: /etc/ssl/cluster-ca/ca.pem
             - name: STKEEPER_PG_SSL_CIPHERS
-              value: "ECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED"
+              value: >-
+                ECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:
+                EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:
+                EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:
+                EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:
+                !DSS:!RC4:!SEED
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/resources/keeper.yaml
+++ b/resources/keeper.yaml
@@ -90,6 +90,7 @@ spec:
         app: stolon
         component: keeper
     spec:
+      serviceAccountName: stolon-keeper
       nodeSelector:
         stolon-keeper: "yes"
       containers:

--- a/resources/restore.yaml
+++ b/resources/restore.yaml
@@ -60,6 +60,7 @@ spec:
       labels:
         name: stolon-restore
     spec:
+      serviceAccountName: stolon-restore
       nodeSelector:
         stolon-keeper: "yes"
       containers:

--- a/resources/restore.yaml
+++ b/resources/restore.yaml
@@ -1,5 +1,55 @@
-apiVersion: extensions/v1beta1
-kind: Deployment
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-restore
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-restore
+  namespace: default
+rules:
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
+    resourceNames:
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-restore
+subjects:
+  - kind: ServiceAccount
+    name: stolon-restore
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-restore
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: stolon-restore
   namespace: default

--- a/resources/restore.yaml
+++ b/resources/restore.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: stolon-restore
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
@@ -39,6 +40,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: stolon-restore
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: stolon-restore
@@ -59,6 +61,7 @@ spec:
     metadata:
       labels:
         name: stolon-restore
+        namespace: default
     spec:
       serviceAccountName: stolon-restore
       nodeSelector:

--- a/resources/rpc.yaml
+++ b/resources/rpc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: stolon-rpc
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
@@ -41,6 +42,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: stolon-rpc
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: stolon-rpc
@@ -78,6 +80,7 @@ spec:
     metadata:
       labels:
         name: stolon-rpc
+        namespace: default
         stolon-cluster: "kube-stolon"
         stolon-rpc: "yes"
         app: stolon

--- a/resources/rpc.yaml
+++ b/resources/rpc.yaml
@@ -83,6 +83,7 @@ spec:
         app: stolon
         component: rpc
     spec:
+      serviceAccountName: stolon-rpc
       nodeSelector:
         stolon-keeper: "yes"
       containers:

--- a/resources/rpc.yaml
+++ b/resources/rpc.yaml
@@ -1,3 +1,55 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-rpc
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-rpc
+  namespace: default
+rules:
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
+    resourceNames:
+      - stolon
+      - cluster-ca
+      - cluster-default-ssl
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-rpc
+subjects:
+  - kind: ServiceAccount
+    name: stolon-rpc
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-rpc
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/resources/sentinel.yaml
+++ b/resources/sentinel.yaml
@@ -1,3 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-sentinel
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-sentinel
+  namespace: default
+rules:
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
+    resourceNames:
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-sentinel
+subjects:
+  - kind: ServiceAccount
+    name: stolon-sentinel
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-sentinel
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/resources/sentinel.yaml
+++ b/resources/sentinel.yaml
@@ -64,6 +64,7 @@ spec:
         app: stolon
         component: sentinel
     spec:
+      serviceAccountName: stolon-sentinel
       nodeSelector:
         stolon-keeper: "yes"
       containers:

--- a/resources/sentinel.yaml
+++ b/resources/sentinel.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: stolon-sentinel
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
@@ -39,6 +40,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: stolon-sentinel
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: stolon-sentinel
@@ -59,6 +61,7 @@ spec:
     metadata:
       labels:
         name: stolon-sentinel
+        namespace: default
         stolon-cluster: "kube-stolon"
         stolon-sentinel: "yes"
         app: stolon

--- a/resources/utils.yaml
+++ b/resources/utils.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: stolon-utils
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: Role
@@ -39,6 +40,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: stolon-utils
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: stolon-utils
@@ -59,6 +61,7 @@ spec:
     metadata:
       labels:
         name: stolon-utils
+        namespace: default
         stolon-cluster: "kube-stolon"
         stolon-utils: "yes"
         app: stolon

--- a/resources/utils.yaml
+++ b/resources/utils.yaml
@@ -1,3 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stolon-utils
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: Role
+metadata:
+  name: stolon-utils
+  namespace: default
+rules:
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
+    resourceNames:
+      - stolon
+  - apiGroups:
+      -  ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: stolon-utils
+subjects:
+  - kind: ServiceAccount
+    name: stolon-utils
+    namespace: default
+roleRef:
+  kind: Role
+  name: stolon-utils
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/resources/utils.yaml
+++ b/resources/utils.yaml
@@ -64,6 +64,7 @@ spec:
         app: stolon
         component: utils
     spec:
+      serviceAccountName: stolon-utils
       nodeSelector:
         stolon-keeper: "yes"
       containers:


### PR DESCRIPTION
This fully wraps up the addition of per-pod serviceAccounts with limited permissions.

I tested installing this version from scratch and updating from 1.5.0 and from 1.6.0, on 1node and 3 nodes and it all worked fine.