### PR TITLE
Run build/robotest containers as non-root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GRAVITY_VERSION ?= 7.0.16
 CLUSTER_SSL_APP_VERSION ?= "0.0.0+latest"
 
 SRCDIR=/go/src/github.com/gravitational/stolon-app
-DOCKERFLAGS=--rm=true -v $(PWD):$(SRCDIR) -w $(SRCDIR)
+DOCKERFLAGS=--rm=true -u $$(id -u):$$(id -g) -e GOCACHE=/tmp/.cache -v $(PWD):$(SRCDIR) -v $(GOPATH)/pkg:/gopath/pkg -w $(SRCDIR)
 BUILDBOX=stolon-app-buildbox:latest
 
 EXTRA_GRAVITY_OPTIONS ?=

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GRAVITY_VERSION ?= 7.0.16
 CLUSTER_SSL_APP_VERSION ?= "0.0.0+latest"
 
 SRCDIR=/go/src/github.com/gravitational/stolon-app
-DOCKERFLAGS=--rm=true -u $$(id -u):$$(id -g) -e GOCACHE=/tmp/.cache -v $(PWD):$(SRCDIR) -v $(GOPATH)/pkg:/gopath/pkg -w $(SRCDIR)
+DOCKERFLAGS=--rm=true -u $$(id -u):$$(id -g) -e XDG_CACHE_HOME=/tmp/.cache -v $(PWD):$(SRCDIR) -v $(GOPATH)/pkg:/gopath/pkg -w $(SRCDIR)
 BUILDBOX=stolon-app-buildbox:latest
 
 EXTRA_GRAVITY_OPTIONS ?=

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -28,7 +28,14 @@ export GCE_VM=${GCE_VM:-custom-4-8192}
 export PARALLEL_TESTS=${PARALLEL_TESTS:-4}
 export REPEAT_TESTS=${REPEAT_TESTS:-1}
 export RETRIES=${RETRIES:-1}
-export DOCKER_RUN_FLAGS=${DOCKER_RUN_FLAGS:-"-u $(id -u)"}
+export DOCKER_RUN_FLAGS=${DOCKER_RUN_FLAGS:-"--rm=true --user=$(id -u):$(id -g)"}
+
+# Work around a bug in https://github.com/gravitational/robotest/blob/v2.1.0/docker/suite/run_suite.sh#L21-L30
+# which mounts a volume inside a volume, resulting in docker creating the inner mountpoint
+# owned by root:root if it does not already exist.
+INSTALLER_BINDIR="$(dirname ${INSTALLER_URL})/bin"
+mkdir -p "${INSTALLER_BINDIR}"
+
 
 # set SUITE and UPGRADE_VERSIONS
 case $TARGET in


### PR DESCRIPTION
Jenkins is having trouble cleaning up after pithos PR builds due to docker creating some files as root:

```
[jenkins@jenkins workspace]$ find Stolon* \! -user jenkins -print
Stolon_PR-177-53WW762547SHYSNAYKY46CP7GUYXSRIJU2DQZWG5AEEYLLTR5V3A-5/build/stolonctl
Stolon_PR-177-53WW762547SHYSNAYKY46CP7GUYXSRIJU2DQZWG5AEEYLLTR5V3A-5/build/stolonboot
Stolon_PR-177-53WW762547SHYSNAYKY46CP7GUYXSRIJU2DQZWG5AEEYLLTR5V3A-7/build/stolonctl
Stolon_PR-177-53WW762547SHYSNAYKY46CP7GUYXSRIJU2DQZWG5AEEYLLTR5V3A-7/build/stolonboot
Stolon_version_1.12.x-7EN4HFEERAC6U5AOXK3UZQ4U6EVMAKWJ5RQGOZDU2LRBEYQ3YDEQ-1/build/stolonctl
Stolon_version_1.12.x-7EN4HFEERAC6U5AOXK3UZQ4U6EVMAKWJ5RQGOZDU2LRBEYQ3YDEQ-1/build/bin
Stolon_version_1.12.x-7EN4HFEERAC6U5AOXK3UZQ4U6EVMAKWJ5RQGOZDU2LRBEYQ3YDEQ-1/build/stolonboot
Stolon_version_1.12.x-7EN4HFEERAC6U5AOXK3UZQ4U6EVMAKWJ5RQGOZDU2LRBEYQ3YDEQ-2/build/stolonctl
Stolon_version_1.12.x-7EN4HFEERAC6U5AOXK3UZQ4U6EVMAKWJ5RQGOZDU2LRBEYQ3YDEQ-2/build/bin
...
```

This fixes `stolonctl`/`stolonboot` (the first commit) and `build/bin` (the second commit).

I manually cleaned up ~.5TB of files last friday -- and will catch the rest once this and https://github.com/gravitational/pithos-app/pull/143 merges into all relevant branches (1.12.x?)

# Testing Done
Before
```
walt@work:~/git/stolon-app$ make build-stolonctl build-stolonboot
docker run --rm=true -v /home/walt/git/stolon-app:/go/src/github.com/gravitational/stolon-app -w /go/src/github.com/gravitational/stolon-app stolon-app-buildbox:latest make build-stolonctl-docker
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o build/stolonctl cmd/stolonctl/*.go
docker run --rm=true -v /home/walt/git/stolon-app:/go/src/github.com/gravitational/stolon-app -w /go/src/github.com/gravitational/stolon-app stolon-app-buildbox:latest make build-stolonboot-docker
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o build/stolonboot cmd/stolonboot/*.go
walt@work:~/git/stolon-app$ ls -l build                          
total 70176
-rwxr-xr-x 1 root root 31181904 Nov  9 10:46 stolonboot
-rwxr-xr-x 1 root root 40673585 Nov  9 10:46 stolonctl
```

After
```
walt@work:~/git/stolon-app$ make build-stolonctl build-stolonboot
mkdir -p build
docker run --rm=true -u $(id -u):$(id -g) -e GOCACHE=/tmp/.cache -v /home/walt/git/stolon-app:/go/src/github.com/gravitational/stolon-app -v /pkg:/gopath/pkg -w /go/src/github.com/gravitational/stolon-app stolon-app-buildbox:latest make build-stolonctl-docker
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o build/stolonctl cmd/stolonctl/*.go
docker run --rm=true -u $(id -u):$(id -g) -e GOCACHE=/tmp/.cache -v /home/walt/git/stolon-app:/go/src/github.com/gravitational/stolon-app -v /pkg:/gopath/pkg -w /go/src/github.com/gravitational/stolon-app stolon-app-buildbox:latest make build-stolonboot-docker
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o build/stolonboot cmd/stolonboot/*.go
walt@work:~/git/stolon-app$ ls -l build
total 70180
-rwxr-xr-x 1 walt walt 31181904 Nov  9 10:48 stolonboot
-rwxr-xr-x 1 walt walt 40673585 Nov  9 10:48 stolonctl
```

Lint after:
```
walt@work:~/git/stolon-app$ make lint                                                                                                                                                         
cd images && make -f Makefile buildbox                                                                                                                                                        
make[1]: Entering directory '/home/walt/git/stolon-app/images'                                                                                                                                
docker build --pull --build-arg GOLANGCI_LINT_VER=1.30.0 -t stolon-app-buildbox:latest /home/walt/git/stolon-app/images/buildbox                                                              
Sending build context to Docker daemon  2.048kB                                                                                                                                               
Step 1/5 : FROM quay.io/gravitational/debian-grande:buster as downloader                                                                                                                      
buster: Pulling from gravitational/debian-grande                                                                                                                                              
Digest: sha256:19220d2090d6d35a52dc1097c3340cf928b8511a595825ca854aab5b63f0ce19                                                                                                               
Status: Image is up to date for quay.io/gravitational/debian-grande:buster                                                                                                                    
 ---> 667ea332b403                                                                                                                                                                            
Step 2/5 : ARG GOLANGCI_LINT_VER                                                                                                                                                              
 ---> Using cache                                                                                                                                                                             
 ---> c31a43319eb2                                                                                                                                                                            
Step 3/5 : RUN apt-get update && apt-get install wget -yy &&     wget https://github.com/golangci/golangci-lint/releases/download/v$GOLANGCI_LINT_VER/golangci-lint-$GOLANGCI_LINT_VER-linux-a
md64.tar.gz &&  tar -xvf golangci-lint-$GOLANGCI_LINT_VER-linux-amd64.tar.gz     golangci-lint-$GOLANGCI_LINT_VER-linux-amd64/golangci-lint --strip-components=1                              
 ---> Using cache                                                                                                                                                                             
 ---> f34fff4100ed                                                                                                                                                                            
Step 4/5 : FROM golang:1.13-buster                                                                                                                                                            
1.13-buster: Pulling from library/golang                                                                                                                                                      
Digest: sha256:66a3f6817c129f48c9cc9b96816a1c0b6dcb399393196e3581d9367b55ab29f2                                                                                                               
Status: Image is up to date for golang:1.13-buster                                                                                                                                            
 ---> d6f3656320fe                                                                                                                                                                            
Step 5/5 : COPY --from=downloader /golangci-lint /usr/local/bin/                                                                                                                              
 ---> Using cache                                                                                                                                                                             
 ---> f6e53162158e                                                                                                                                                                            
Successfully built f6e53162158e                                                                                                                                                               
Successfully tagged stolon-app-buildbox:latest                                                                                                                                                
make[1]: Leaving directory '/home/walt/git/stolon-app/images'                                                                                                                                 
docker run --rm=true -u $(id -u):$(id -g) -e XDG_CACHE_HOME=/tmp/.cache -v /home/walt/git/stolon-app:/go/src/github.com/gravitational/stolon-app -v /pkg:/gopath/pkg -w /go/src/github.com/gravitational/stolon-app stolon-app-buildbox:latest golangci-lint run --timeout=5m --skip-dirs=vendor ./...
```

Testing for the run.sh changes can be seen at https://github.com/gravitational/gravity/pull/2153.

## TODO
 - [ ] Validate this pr build successfully completes
 - [x] Validate there are no files owned by anything other than jenkins in the build directory 