### PR TITLE
Revive RUN_UPGRADE flag.

### DIFF
--- a/robotest/pr_config.sh
+++ b/robotest/pr_config.sh
@@ -5,6 +5,8 @@ set -o pipefail
 
 source $(dirname $0)/utils.sh
 
+readonly RUN_UPGRADE=${RUN_UPGRADE:-0}
+
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
 
@@ -55,7 +57,9 @@ EOF
 
 SUITE=$(build_install_suite)
 #SUITE="$SUITE $(build_resize_suite)"
-SUITE="$SUITE $(build_upgrade_suite)"
+if [ "$RUN_UPGRADE" == "1" ]; then
+  SUITE="$SUITE $(build_upgrade_suite)"
+fi
 
 echo "$SUITE" | tr ' ' '\n'
 


### PR DESCRIPTION
This flag has been broken since robotest was refactored in
db78710545794e495becc0888637a1fbf5abff1a.

## Testing done:

In progress.

* With `RUN_UPGRADE=0`: [logs](https://jenkins.gravitational.io/job/Stolon/job/PR-179/4/console) (25m to complete, no upgrades)
* With `RUN_UPGRADE=1`: [logs](https://jenkins.gravitational.io/job/Stolon/job/PR-179/10/console) (60m to complete, upgrades run)