### PR TITLE
[1.12.x] CI fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GRAVITY_VERSION ?= 5.5.51
 CLUSTER_SSL_APP_VERSION ?= "0.0.0+latest"
 
 SRCDIR=/go/src/github.com/gravitational/stolon-app
-DOCKERFLAGS=--rm=true -v $(PWD):$(SRCDIR) -w $(SRCDIR)
+DOCKERFLAGS=--rm=true -u $$(id -u):$$(id -g) -e XDG_CACHE_HOME=/tmp/.cache -v $(PWD):$(SRCDIR) -v $(GOPATH)/pkg:/gopath/pkg -w $(SRCDIR)
 BUILDBOX=stolon-app-buildbox:latest
 
 EXTRA_GRAVITY_OPTIONS ?=

--- a/robotest/pr_config.sh
+++ b/robotest/pr_config.sh
@@ -5,6 +5,8 @@ set -o pipefail
 
 source $(dirname $0)/utils.sh
 
+readonly RUN_UPGRADE=${RUN_UPGRADE:-0}
+
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
 
@@ -55,7 +57,9 @@ EOF
 
 SUITE=$(build_install_suite)
 #SUITE="$SUITE $(build_resize_suite)"
-SUITE="$SUITE $(build_upgrade_suite)"
+if [ "$RUN_UPGRADE" == "1" ]; then
+  SUITE="$SUITE $(build_upgrade_suite)"
+fi
 
 echo "$SUITE" | tr ' ' '\n'
 

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -28,7 +28,14 @@ export GCE_VM=${GCE_VM:-custom-4-8192}
 export PARALLEL_TESTS=${PARALLEL_TESTS:-4}
 export REPEAT_TESTS=${REPEAT_TESTS:-1}
 export RETRIES=${RETRIES:-1}
-export DOCKER_RUN_FLAGS=${DOCKER_RUN_FLAGS:-"-u $(id -u)"}
+export DOCKER_RUN_FLAGS=${DOCKER_RUN_FLAGS:-"--rm=true --user=$(id -u):$(id -g)"}
+
+# Work around a bug in https://github.com/gravitational/robotest/blob/v2.1.0/docker/suite/run_suite.sh#L21-L30
+# which mounts a volume inside a volume, resulting in docker creating the inner mountpoint
+# owned by root:root if it does not already exist.
+INSTALLER_BINDIR="$(dirname ${INSTALLER_URL})/bin"
+mkdir -p "${INSTALLER_BINDIR}"
+
 
 # set SUITE and UPGRADE_VERSIONS
 case $TARGET in


### PR DESCRIPTION
This backports https://github.com/gravitational/stolon-app/pull/178 and https://github.com/gravitational/stolon-app/pull/179.

These changes fix the `RUN_UPGRADE` environment variable, and change ownership from root to the current user for several build artifacts/files.