### PR TITLE
Check for existing job before trying to use it for kubectl

### DIFF
--- a/images/hook/update.sh
+++ b/images/hook/update.sh
@@ -3,7 +3,7 @@
 set -o nounset
 set -o errexit
 set -o pipefail
-
+set -o xtrace
 
 export EXTRA_PARAMS=""
 if [ -f /var/lib/gravity/resources/custom-build.yaml ]
@@ -77,8 +77,8 @@ fi
 set +e
 helm upgrade --install stolon /var/lib/gravity/resources/charts/stolon \
      --values /var/lib/gravity/resources/custom-values.yaml $EXTRA_PARAMS
-
 set -e
 
+timeout 5m bash -c "while ! kubectl get job stolon-postgres-hardening; do sleep 10; done"
 kubectl wait --for=condition=complete --timeout=5m job/stolon-postgres-hardening
 rig freeze


### PR DESCRIPTION
----

# Workaround the problem with helm 2 when it could not read logs

``` shell
ip-10-1-0-7:/$ kubectl logs stolon-app-install-c83fa5-7c8w6
E1214 13:27:59.873734       6 portforward.go:233] lost connection to pod
E1214 13:27:59.873734       6 portforward.go:233] lost connection to pod
log: exiting because of error: log: cannot create log: open /tmp/helm.stolon-app-install-c83fa5-7c8w6.unknownuser.log.ERROR.20201214-132759.6: no such file or directory
Error from server (NotFound): jobs.batch "stolon-postgres-hardening" not found
```