### PR TITLE
Add Drone CI for pull requests 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,103 @@
+---
+kind: pipeline
+type: kubernetes
+name: pr
+
+trigger:
+  event:
+  - pull_request
+
+environment:
+  STATEDIR: /drone/src/state
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: download binaries
+    image: docker:git
+    commands:
+      - apk add --no-cache make curl
+      - make download-binaries
+  - name: login to opscenter
+    image: docker:git
+    environment:
+      OPS_URL:
+        from_secret: OPS_URL
+      API_KEY:
+        from_secret: OPS_API_KEY_RO
+    commands:
+      # tele is built against glibc. Alpine's musl libc is glibc compatible, but needs to be linked into place.
+      - apk add --no-cache libc6-compat
+      - ./bin/tele login --state-dir=$STATEDIR --ops $OPS_URL --token=$API_KEY
+  - name: build
+    image: docker:git
+    environment:
+      OPS_URL:
+        from_secret: OPS_URL
+    commands:
+      - apk add --no-cache make libc6-compat
+      # add binaries downloaded in "download binaries" step to path
+      - export PATH=$PATH:$(pwd)/bin
+      - export EXTRA_GRAVITY_OPTIONS=--state-dir=$STATEDIR
+      - export INTERMEDIATE_RUNTIME_VERSION=6.1.43
+      - make build-app
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: robotest
+    image: docker:git
+    environment:
+      GCP_ROBOTEST_CREDENTIALS:
+        from_secret: GCP_ROBOTEST_CREDENTIALS
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      # These files need to be in a volume that the docker service has access to
+      # We choose /tmp to accommodate https://github.com/gravitational/robotest/blob/3774f8641439b19c4e0e598db8f87c52ea0e4817/docker/suite/run_suite.sh#L106
+      SSH_KEY: /tmp/secrets/robotest
+      SSH_PUB: /tmp/secrets/robotest.pub
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/secrets/gcp.json
+    commands:
+      - apk add --no-cache make bash aws-cli
+      - mkdir -p $(dirname $SSH_KEY)
+      - ssh-keygen -t ed25519 -N '' -f $SSH_KEY
+      - echo "$GCP_ROBOTEST_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+      - make robotest-run-suite
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+volumes:
+  - name: dockersock
+    temp: {}
+  - name: dockertmp
+    temp: {}
+---
+kind: signature
+hmac: 7dd7fb567c39565eb79fcfecbafc80e916c8addcc40ba90c5e1bf4344a3c49fd
+
+...

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ properties([
            defaultValue: '0',
            description: 'How many times to retry each failed test'),
     string(name: 'ROBOTEST_VERSION',
-           defaultValue: 'uid-gid',
+           defaultValue: '2.2.0',
            description: 'Robotest tag to use.'),
     booleanParam(name: 'ROBOTEST_RUN_UPGRADE',
            defaultValue: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ properties([
            description: 'Gravity options to add when calling tele'),
     string(name: 'TELE_BUILD_EXTRA_OPTIONS',
            defaultValue: '',
-           description: 'Extraoptions to add when calling tele build'),
+           description: 'Extra options to add when calling tele build'),
     booleanParam(name: 'ADD_GRAVITY_VERSION',
                  defaultValue: false,
                  description: 'Appends "-${GRAVITY_VERSION}" to the tag to be published'),

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ BUILDBOX=stolon-app-buildbox:latest
 
 EXTRA_GRAVITY_OPTIONS ?=
 TELE_BUILD_EXTRA_OPTIONS ?=
+
+# work around https://github.com/gravitational/gravity/issues/2060,
+# --parallel may no longer be needed if GRAVITY_VERSION >> 7.0.15 -- 2020-01 walt
+TELE_BUILD_EXTRA_OPTIONS += --parallel=1
+
 # if variable is not empty add an extra parameter to tele build
 ifneq ($(INTERMEDIATE_RUNTIME_VERSION),)
 	TELE_BUILD_EXTRA_OPTIONS +=  --upgrade-via=$(INTERMEDIATE_RUNTIME_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -108,17 +108,18 @@ import: images
 	sed -i "s/tag: $(VERSION)/tag: latest/g" resources/charts/stolon/values.yaml
 	sed -i "s/$(VERSION)/0.1.0/g" resources/charts/stolon/Chart.yaml
 
+# .PHONY because VERSION/RUNTIME_VERSION are dynamic
+.PHONY: $(BUILD_DIR)/resources/app.yaml
+$(BUILD_DIR)/resources/app.yaml: | $(BUILD_DIR)
+	cp --archive resources $(BUILD_DIR)
+	sed -i "s/version: \"0.0.0+latest\"/version: \"$(RUNTIME_VERSION)\"/" $(BUILD_DIR)/resources/app.yaml
+	sed -i "s#gravitational.io/cluster-ssl-app:0.0.0+latest#gravitational.io/cluster-ssl-app:$(CLUSTER_SSL_APP_VERSION)#" $(BUILD_DIR)/resources/app.yaml
+	sed -i "s/tag: latest/tag: $(VERSION)/g" $(BUILD_DIR)/resources/charts/stolon/values.yaml
+	sed -i "s/0.1.0/$(VERSION)/g" $(BUILD_DIR)/resources/charts/stolon/Chart.yaml
+
 .PHONY: build-app
-build-app: images
-	sed -i "s/version: \"0.0.0+latest\"/version: \"$(RUNTIME_VERSION)\"/" resources/app.yaml
-	sed -i "s#gravitational.io/cluster-ssl-app:0.0.0+latest#gravitational.io/cluster-ssl-app:$(CLUSTER_SSL_APP_VERSION)#" resources/app.yaml
-	sed -i "s/tag: latest/tag: $(VERSION)/g" resources/charts/stolon/values.yaml
-	sed -i "s/0.1.0/$(VERSION)/g" resources/charts/stolon/Chart.yaml
-	$(TELE) build -f -o $(BUILD_DIR)/installer.tar $(TELE_BUILD_OPTIONS) $(EXTRA_GRAVITY_OPTIONS) resources/app.yaml
-	sed -i "s/version: \"$(RUNTIME_VERSION)\"/version: \"0.0.0+latest\"/" resources/app.yaml
-	sed -i "s#gravitational.io/cluster-ssl-app:$(CLUSTER_SSL_APP_VERSION)#gravitational.io/cluster-ssl-app:0.0.0+latest#" resources/app.yaml
-	sed -i "s/tag: $(VERSION)/tag: latest/g" resources/charts/stolon/values.yaml
-	sed -i "s/$(VERSION)/0.1.0/g" resources/charts/stolon/Chart.yaml
+build-app: images $(BUILD_DIR)/resources/app.yaml
+	$(TELE) build -f -o $(BUILD_DIR)/installer.tar $(TELE_BUILD_OPTIONS) $(EXTRA_GRAVITY_OPTIONS) $(BUILD_DIR)/resources/app.yaml
 
 .PHONY: build-gravity-app
 build-gravity-app: images

--- a/Makefile
+++ b/Makefile
@@ -172,3 +172,7 @@ lint: buildbox
 .PHONY: push
 push:
 	$(TELE) push -f $(EXTRA_GRAVITY_OPTIONS) $(BUILD_DIR)/installer.tar
+
+.PHONY: get-version
+get-version:
+	@echo $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-export VERSION ?= $(shell ./version.sh)
+ifeq ($(origin VERSION), undefined)
+# avoid ?= lazily evaluating version.sh (and thus rerunning the shell command several times)
+VERSION := $(shell ./version.sh)
+endif
 REPOSITORY := gravitational.io
 NAME := stolon-app
 OPS_URL ?= https://opscenter.localhost.localdomain:33009

--- a/images/Makefile
+++ b/images/Makefile
@@ -62,7 +62,7 @@ $(IMAGES_FOR_BUILD):
 
 .PHONY: hook
 hook:
-	$(eval CHANGESET = $(shell echo $$VERSION | sed -e 's/[\.]//g'))
+	$(eval CHANGESET = $(shell echo '$(VERSION)' | sed -e 's/[\.]//g'))
 	if [ -z "$(CHANGESET)" ]; then \
 		echo "CHANGESET is not set"; exit 1; \
 	fi;

--- a/robotest/pr_config.sh
+++ b/robotest/pr_config.sh
@@ -11,7 +11,7 @@ readonly RUN_UPGRADE=${RUN_UPGRADE:-0}
 declare -A UPGRADE_MAP
 
 # TODO (Sergei): enable upgrades from recommended tags
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 1.12.x))]="ubuntu:18" # this branch
+UPGRADE_MAP[1.12.10]="ubuntu:18" # this branch
 
 # via intermediate upgrade
 UPGRADE_MAP[1.12.7]="centos:7"

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -11,7 +11,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-uid-gid}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$(pwd)/build/installer.tar
 export GRAVITY_URL=$(pwd)/bin/gravity

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -56,7 +56,9 @@ export EXTRA_VOLUME_MOUNTS=$(build_volume_mounts)
 mkdir -p $UPGRADE_FROM_DIR
 for release in ${!UPGRADE_MAP[@]}; do
   if [ ! -f $UPGRADE_FROM_DIR/$(tag_to_tarball ${release}) ]; then
-      aws s3 cp s3://builds.gravitational.io/stolon/$(tag_to_tarball ${release}) $UPGRADE_FROM_DIR/$(tag_to_tarball ${release})
+      # aws s3 cp has incredibly verbose progress, disable progress for the sake of concise CI logs
+      [[ -z ${CI:-} ]] || S3_FLAGS=--no-progress
+      aws s3 cp ${S3_FLAGS:-} s3://builds.gravitational.io/stolon/$(tag_to_tarball ${release}) $UPGRADE_FROM_DIR/$(tag_to_tarball ${release})
   fi
 done
 

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,7 @@
 
 # this versioning algo:
 # keeps tag as is in case if this version is an equal match
-# otherwise adds .<number of commits since last tag>
+# otherwise adds -dev.<number of commits since last tag>
 
 SHORT_TAG=`git describe --abbrev=0 --tags`
 LONG_TAG=`git describe --tags`
@@ -12,7 +12,7 @@ COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 if [ "$LONG_TAG" = "$SHORT_TAG" ] ; then  # the current commit is tagged as a release
     echo "$SHORT_TAG"
 elif echo "$SHORT_TAG" | grep -Eq ".*-.*"; then  # the current commit is a descendant of a pre-release version (e.g. rc, alpha, or beta)
-    echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
+    echo "$SHORT_TAG-dev.${COMMITS_SINCE_LAST_TAG}"
 else   # the current commit is a descendant of a regular version
-    echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
+    echo "$SHORT_TAG-dev.${COMMITS_SINCE_LAST_TAG}"
 fi

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # this versioning algo:
 # keeps tag as is in case if this version is an equal match
@@ -9,10 +9,10 @@ LONG_TAG=`git describe --tags`
 COMMIT_WITH_LAST_TAG=`git show-ref --tags --dereference | grep "refs/tags/${SHORT_TAG}^{}" | awk '{print $1}'`
 COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 
-if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then
+if [ "$LONG_TAG" = "$SHORT_TAG" ] ; then  # the current commit is tagged as a release
     echo "$SHORT_TAG"
-elif [[ "$SHORT_TAG" != *-* ]] ; then
+elif echo "$SHORT_TAG" | grep -Eq ".*-.*"; then  # the current commit is a descendant of a pre-release version (e.g. rc, alpha, or beta)
     echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
-else
+else   # the current commit is a descendant of a regular version
     echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
 fi


### PR DESCRIPTION
## Summary
This patch adds an intial Drone CI config that builds and exercises the stolon cluster image upon PR.

## Testing Done
Most importantly, the Drone CI build on this PR passes.
Builds along the way found here: https://drone.gravitational.io/gravitational/stolon-app/

## Notes
This is largely drawn from the Pithos Drone config (https://github.com/gravitational/pithos-app/pull/152 and https://github.com/gravitational/pithos-app/pull/153). The only notable change is: I include `tele build --parallel=1` to avoid a race as Stolon is using an older base gravity.

The ci-ops user is the same as used for Pithos `ci-user-ro`, however I did provision a unique token that is only used by this build.  Check it with `gravity resource get token --user ci-user-ro@gravitational.com --format yaml` and look for the token that starts with `drone-ci-ro-stolon`

Similarly, unique minimal S3 creds were provisioned in https://github.com/gravitational/cloud-terraform/pull/120.  Find the token in 1Password under `drone-ci-s3-builds-gravitational-io-stolon-readonly`.

GCP robotest credentials were provisioned by hand using the Robotest role.  Token in 1Password by seaching for `drone-stolon-robotest`.
