### PR TITLE
[1.12.x] Backport Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,103 @@
+---
+kind: pipeline
+type: kubernetes
+name: pr
+
+trigger:
+  event:
+  - pull_request
+
+environment:
+  STATEDIR: /drone/src/state
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: download binaries
+    image: docker:git
+    commands:
+      - apk add --no-cache make curl
+      - make download-binaries
+  - name: login to opscenter
+    image: docker:git
+    environment:
+      OPS_URL:
+        from_secret: OPS_URL
+      API_KEY:
+        from_secret: OPS_API_KEY_RO
+    commands:
+      # tele is built against glibc. Alpine's musl libc is glibc compatible, but needs to be linked into place.
+      - apk add --no-cache libc6-compat
+      - ./bin/tele login --state-dir=$STATEDIR --ops $OPS_URL --token=$API_KEY
+  - name: build
+    image: docker:git
+    environment:
+      OPS_URL:
+        from_secret: OPS_URL
+    commands:
+      - apk add --no-cache make libc6-compat
+      # add binaries downloaded in "download binaries" step to path
+      - export PATH=$PATH:$(pwd)/bin
+      - export EXTRA_GRAVITY_OPTIONS=--state-dir=$STATEDIR
+      - export INTERMEDIATE_RUNTIME_VERSION=5.2.17
+      - make build-app
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: robotest
+    image: docker:git
+    environment:
+      GCP_ROBOTEST_CREDENTIALS:
+        from_secret: GCP_ROBOTEST_CREDENTIALS
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      # These files need to be in a volume that the docker service has access to
+      # We choose /tmp to accommodate https://github.com/gravitational/robotest/blob/3774f8641439b19c4e0e598db8f87c52ea0e4817/docker/suite/run_suite.sh#L106
+      SSH_KEY: /tmp/secrets/robotest
+      SSH_PUB: /tmp/secrets/robotest.pub
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/secrets/gcp.json
+    commands:
+      - apk add --no-cache make bash aws-cli
+      - mkdir -p $(dirname $SSH_KEY)
+      - ssh-keygen -t ed25519 -N '' -f $SSH_KEY
+      - echo "$GCP_ROBOTEST_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+      - make robotest-run-suite
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+volumes:
+  - name: dockersock
+    temp: {}
+  - name: dockertmp
+    temp: {}
+---
+kind: signature
+hmac: 496b1500f1e1578a7782cdcef8356391f717a2274a193a255f4261e187a2009a
+
+...

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ properties([
            defaultValue: '0',
            description: 'How many times to retry each failed test'),
     string(name: 'ROBOTEST_VERSION',
-           defaultValue: 'uid-gid',
+           defaultValue: '2.2.0',
            description: 'Robotest tag to use.'),
     booleanParam(name: 'ROBOTEST_RUN_UPGRADE',
            defaultValue: false,

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-export VERSION ?= $(shell ./version.sh)
+ifeq ($(origin VERSION), undefined)
+# avoid ?= lazily evaluating version.sh (and thus rerunning the shell command several times)
+VERSION := $(shell ./version.sh)
+endif
 REPOSITORY := gravitational.io
 NAME := stolon-app
 OPS_URL ?= https://opscenter.localhost.localdomain:33009

--- a/Makefile
+++ b/Makefile
@@ -170,3 +170,7 @@ lint: buildbox
 .PHONY: push
 push:
 	$(TELE) push -f $(EXTRA_GRAVITY_OPTIONS) $(BUILD_DIR)/installer.tar
+
+.PHONY: get-version
+get-version:
+	@echo $(VERSION)

--- a/images/Makefile
+++ b/images/Makefile
@@ -60,7 +60,7 @@ $(IMAGES_FOR_BUILD):
 
 .PHONY: hook
 hook:
-	$(eval CHANGESET = $(shell echo $$VERSION | sed -e 's/[\.]//g'))
+	$(eval CHANGESET = $(shell echo '$(VERSION)' | sed -e 's/[\.]//g'))
 	if [ -z "$(CHANGESET)" ]; then \
 		echo "CHANGESET is not set"; exit 1; \
 	fi;

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -11,7 +11,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-uid-gid}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$(pwd)/build/installer.tar
 export GRAVITY_URL=$(pwd)/bin/gravity

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -56,7 +56,9 @@ export EXTRA_VOLUME_MOUNTS=$(build_volume_mounts)
 mkdir -p $UPGRADE_FROM_DIR
 for release in ${!UPGRADE_MAP[@]}; do
   if [ ! -f $UPGRADE_FROM_DIR/$(tag_to_tarball ${release}) ]; then
-      aws s3 cp s3://builds.gravitational.io/stolon/$(tag_to_tarball ${release}) $UPGRADE_FROM_DIR/$(tag_to_tarball ${release})
+      # aws s3 cp has incredibly verbose progress, disable progress for the sake of concise CI logs
+      [[ -z ${CI:-} ]] || S3_FLAGS=--no-progress
+      aws s3 cp ${S3_FLAGS:-} s3://builds.gravitational.io/stolon/$(tag_to_tarball ${release}) $UPGRADE_FROM_DIR/$(tag_to_tarball ${release})
   fi
 done
 

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,7 @@
 
 # this versioning algo:
 # keeps tag as is in case if this version is an equal match
-# otherwise adds .<number of commits since last tag>
+# otherwise adds -dev.<number of commits since last tag>
 
 SHORT_TAG=`git describe --abbrev=0 --tags`
 LONG_TAG=`git describe --tags`
@@ -12,7 +12,7 @@ COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 if [ "$LONG_TAG" = "$SHORT_TAG" ] ; then  # the current commit is tagged as a release
     echo "$SHORT_TAG"
 elif echo "$SHORT_TAG" | grep -Eq ".*-.*"; then  # the current commit is a descendant of a pre-release version (e.g. rc, alpha, or beta)
-    echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
+    echo "$SHORT_TAG-dev.${COMMITS_SINCE_LAST_TAG}"
 else   # the current commit is a descendant of a regular version
-    echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
+    echo "$SHORT_TAG-dev.${COMMITS_SINCE_LAST_TAG}"
 fi

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # this versioning algo:
 # keeps tag as is in case if this version is an equal match
@@ -9,10 +9,10 @@ LONG_TAG=`git describe --tags`
 COMMIT_WITH_LAST_TAG=`git show-ref --tags --dereference | grep "refs/tags/${SHORT_TAG}^{}" | awk '{print $1}'`
 COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 
-if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then
+if [ "$LONG_TAG" = "$SHORT_TAG" ] ; then  # the current commit is tagged as a release
     echo "$SHORT_TAG"
-elif [[ "$SHORT_TAG" != *-* ]] ; then
+elif echo "$SHORT_TAG" | grep -Eq ".*-.*"; then  # the current commit is a descendant of a pre-release version (e.g. rc, alpha, or beta)
     echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
-else
+else   # the current commit is a descendant of a regular version
     echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
 fi


### PR DESCRIPTION
## Summary
This patch backports Drone CI configs from https://github.com/gravitational/stolon-app/pull/186.

The patches were verbatim aside from updating the intermediate upgrade version and dropping a typo fix that didn't apply.

## Testing Done
See the drone build for this PR.