### PR TITLE
[1.12.x] Bump robotest to 2.2.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ properties([
            defaultValue: '0',
            description: 'How many times to retry each failed test'),
     string(name: 'ROBOTEST_VERSION',
-           defaultValue: '2.2.0',
+           defaultValue: '2.2.1',
            description: 'Robotest tag to use.'),
     booleanParam(name: 'ROBOTEST_RUN_UPGRADE',
            defaultValue: false,

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -11,7 +11,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.0}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.1}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$(pwd)/build/installer.tar
 export GRAVITY_URL=$(pwd)/bin/gravity


### PR DESCRIPTION
## Summary
Backport of https://github.com/gravitational/stolon-app/pull/188

This fixes a bootstrap failure on Ubuntu, Debian and Suse related
to installing awscli.  See:

  https://github.com/gravitational/robotest/issues/279

## Testing Done
None specific to stolon. The PR build is sufficient.

https://github.com/gravitational/robotest/issues/280 has testing related to robotest and different distros.