### PR TITLE
Fix the secret not exist issue for chained upgrade

### DIFF
--- a/images/hook/update.sh
+++ b/images/hook/update.sh
@@ -54,6 +54,12 @@ fi
 
 rig delete secrets/telegraf-influxdb-creds --force
 
+# check whether stolon secret was created not under helm release
+if [[ $(kubectl get secrets stolon -o jsonpath='{.metadata.labels.chart}' | wc -l) -eq 0 ]]
+then
+    rig delete secrets/stolon --force
+fi
+
 # delete jobs from previous run
 for name in stolon-bootstrap-auth-function stolon-copy-telegraf-influxdb-creds \
 					   stolon-create-alerts stolon-postgres-hardening


### PR DESCRIPTION
In the situation when stolon is upgrading in a chain 1.10.x -> <1.12.9 -> 1.12.x newer, the last upgrade is failing because upgrade to <1.12.9 didn't handle `stolon` secret properly.
We especially check here whether `stolon` secret contains Helm specific labels and if not delete the secret to recreate it later by the `helm upgrade --install` command.